### PR TITLE
Simulator Clone Support

### DIFF
--- a/lib/iostrust.rb
+++ b/lib/iostrust.rb
@@ -8,6 +8,7 @@ module Iostrust
       "Application Support/iPhone Simulator/3.*/Library/",
       "Application Support/iPhone Simulator/4.*/Library/",
       "Developer/CoreSimulator/Devices/**/data/Library/",
+      "Developer/XCTestDevices/**/data/Library/",
       "Application Support/iPhone Simulator/User/Library/"
   ]
 


### PR DESCRIPTION
Adding the path for simulator clones so that any clones created before running iOS trust will get the certs added.